### PR TITLE
Maintenance window text

### DIFF
--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/form.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/form.tsx
@@ -104,11 +104,7 @@ export const CreateMaintenanceWindowForm = React.memo<CreateMaintenanceWindowFor
       <Form form={form}>
         <EuiFlexGroup gutterSize="l" responsive={false}>
           <EuiFlexItem>
-            <EuiFlexGrid columns={2} alignItems="start">
-              <SectionTitle
-                title={i18n.CREATE_FORM_DESC_TITLE}
-                description={i18n.CREATE_FORM_DESC_DESCRIPTION}
-              />
+            <EuiFlexGrid columns={1} alignItems="start">
               <EuiFlexItem>
                 <UseField
                   path="title"
@@ -121,10 +117,6 @@ export const CreateMaintenanceWindowForm = React.memo<CreateMaintenanceWindowFor
                   }}
                 />
               </EuiFlexItem>
-              <SectionTitle
-                title={i18n.CREATE_FORM_SCHEDULE_TITLE}
-                description={i18n.CREATE_FORM_SCHEDULE_DESCRIPTION}
-              />
               <EuiFlexItem>
                 <EuiFlexGroup direction="column">
                   <EuiFlexItem>

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/page_header.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/page_header.tsx
@@ -40,47 +40,66 @@ const Title = React.memo<TitleProps>(({ title }) => {
     </EuiFlexGroup>
   );
 });
+
 Title.displayName = 'Title';
+
+interface DescProps {
+  description: string | React.ReactNode;
+}
+const Description = React.memo<DescProps>(({ description }) => {
+  return (
+    <EuiFlexGroup alignItems="baseline" gutterSize="s" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <p>{isString(description) ? <TruncatedText text={description} /> : description}</p>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+});
+Description.displayName = 'Description';
 
 export interface PageHeaderProps {
   showBackButton?: boolean;
   title: string | React.ReactNode;
+  description: string | React.ReactNode;
 }
 
-export const PageHeader = React.memo<PageHeaderProps>(({ showBackButton = false, title }) => {
-  const { getMaintenanceWindowsUrl, navigateToMaintenanceWindows } =
-    useMaintenanceWindowsNavigation();
+export const PageHeader = React.memo<PageHeaderProps>(
+  ({ showBackButton = false, title, description }) => {
+    const { getMaintenanceWindowsUrl, navigateToMaintenanceWindows } =
+      useMaintenanceWindowsNavigation();
 
-  const navigateToMaintenanceWindowsClick = useCallback(
-    (e) => {
-      if (e) {
-        e.preventDefault();
-      }
-      navigateToMaintenanceWindows();
-    },
-    [navigateToMaintenanceWindows]
-  );
+    const navigateToMaintenanceWindowsClick = useCallback(
+      (e) => {
+        if (e) {
+          e.preventDefault();
+        }
+        navigateToMaintenanceWindows();
+      },
+      [navigateToMaintenanceWindows]
+    );
 
-  return (
-    <>
-      <EuiFlexGroup alignItems="center">
-        <EuiFlexItem grow={false}>
-          {showBackButton && (
-            <LinkBack>
-              <LinkIcon
-                onClick={navigateToMaintenanceWindowsClick}
-                href={getMaintenanceWindowsUrl()}
-                iconType="arrowLeft"
-              >
-                {i18n.MAINTENANCE_WINDOWS_RETURN_LINK}
-              </LinkIcon>
-            </LinkBack>
-          )}
-          <Title title={title} />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="xl" />
-    </>
-  );
-});
+    return (
+      <>
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem grow={false}>
+            {showBackButton && (
+              <LinkBack>
+                <LinkIcon
+                  onClick={navigateToMaintenanceWindowsClick}
+                  href={getMaintenanceWindowsUrl()}
+                  iconType="arrowLeft"
+                >
+                  {i18n.MAINTENANCE_WINDOWS_RETURN_LINK}
+                </LinkIcon>
+              </LinkBack>
+            )}
+            <Title title={title} />
+            <Description description={description} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="xl" />
+      </>
+    );
+  }
+);
 PageHeader.displayName = 'PageHeader';

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/schema.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/schema.tsx
@@ -45,7 +45,7 @@ export const schema: FormSchema<FormProps> = {
     ],
   },
   date: {
-    label: i18n.CREATE_FORM_DATE_AND_TIME,
+    label: i18n.CREATE_FORM_SCHEDULE_TITLE,
     defaultValue: moment().toISOString(),
     validations: [],
   },

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/create.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/create.tsx
@@ -20,7 +20,11 @@ export const MaintenanceWindowsCreatePage = React.memo(() => {
 
   return (
     <EuiPageSection restrictWidth={true}>
-      <PageHeader showBackButton={true} title={i18n.CREATE_MAINTENANCE_WINDOW_TITLE} />
+      <PageHeader
+        showBackButton={true}
+        title={i18n.CREATE_MAINTENANCE_WINDOW_TITLE}
+        description={i18n.CREATE_MAINTENANCE_WINDOW_DESCRIPTION}
+      />
       <CreateMaintenanceWindowForm
         onCancel={navigateToMaintenanceWindows}
         onSuccess={navigateToMaintenanceWindows}

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
@@ -108,7 +108,7 @@ export const CREATE_FORM_SCHEDULE_TITLE = i18n.translate(
 export const CREATE_FORM_SCHEDULE_DESCRIPTION = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.scheduleDescription',
   {
-    defaultMessage: 'Define the period and frequency of the maintenance window.',
+    defaultMessage: 'The period and frequency of the maintenance window.',
   }
 );
 

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
@@ -16,7 +16,7 @@ export const MAINTENANCE_WINDOWS = i18n.translate('xpack.alerting.maintenanceWin
 export const MAINTENANCE_WINDOWS_DESCRIPTION = i18n.translate(
   'xpack.alerting.maintenanceWindows.description',
   {
-    defaultMessage: 'Supress notifications for scheduled periods of time.',
+    defaultMessage: 'Suppress rule notifications for scheduled periods of time.',
   }
 );
 
@@ -44,14 +44,22 @@ export const EMPTY_PROMPT_TITLE = i18n.translate(
 export const EMPTY_PROMPT_DESCRIPTION = i18n.translate(
   'xpack.alerting.maintenanceWindows.emptyPrompt.description',
   {
-    defaultMessage: 'Supress notifications while marking associated alerts as `Under Maintenance`',
+    defaultMessage: 'Schedule a time period in which rule notifications cease.',
   }
 );
 
 export const CREATE_MAINTENANCE_WINDOW_TITLE = i18n.translate(
   'xpack.alerting.maintenanceWindows.create.title',
   {
-    defaultMessage: 'Create Maintenance Window',
+    defaultMessage: 'Create maintenance window',
+  }
+);
+
+export const CREATE_MAINTENANCE_WINDOW_DESCRIPTION = i18n.translate(
+  'xpack.alerting.maintenanceWindows.create.description',
+  {
+    defaultMessage:
+      'Schedule a single or recurring period in which rule notifications cease and alerts temporarily have a maintenance status.',
   }
 );
 
@@ -79,14 +87,14 @@ export const CREATE_FORM_NAME_REQUIRED = i18n.translate(
 export const CREATE_FORM_DESC_TITLE = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.describeTitle',
   {
-    defaultMessage: 'Describe your maintenance window',
+    defaultMessage: 'Name',
   }
 );
 
 export const CREATE_FORM_DESC_DESCRIPTION = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.describeDescription',
   {
-    defaultMessage: 'This will be used to reference the maintenance window.',
+    defaultMessage: 'A unique identifier for your maintenance window.',
   }
 );
 
@@ -100,21 +108,21 @@ export const CREATE_FORM_SCHEDULE_TITLE = i18n.translate(
 export const CREATE_FORM_SCHEDULE_DESCRIPTION = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.scheduleDescription',
   {
-    defaultMessage: 'Define when and how often you would like actions to be snoozed.',
+    defaultMessage: 'Define the period and frequency of the maintenance window.',
   }
 );
 
 export const CREATE_FORM_DATE_AND_TIME = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.dateAndTime',
   {
-    defaultMessage: 'Date & time',
+    defaultMessage: 'Date and time',
   }
 );
 
 export const CREATE_FORM_DATE_AND_TIME_REQUIRED = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.dateAndTimeFieldRequiredError',
   {
-    defaultMessage: 'Date & time is required.',
+    defaultMessage: 'Date and time are required.',
   }
 );
 
@@ -142,7 +150,7 @@ export const CREATE_FORM_DURATION_REQUIRED = i18n.translate(
 export const CREATE_FORM_RECURRING = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.recurring',
   {
-    defaultMessage: 'Make recurring',
+    defaultMessage: 'Repeat',
   }
 );
 
@@ -242,7 +250,7 @@ export const CREATE_FORM_ENDS_NEVER = i18n.translate(
 export const CREATE_FORM_ENDS_ON_DATE = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.ends.onDate',
   {
-    defaultMessage: 'On Date',
+    defaultMessage: 'On date',
   }
 );
 

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
@@ -59,7 +59,7 @@ export const CREATE_MAINTENANCE_WINDOW_DESCRIPTION = i18n.translate(
   'xpack.alerting.maintenanceWindows.create.description',
   {
     defaultMessage:
-      'Schedule a single or recurring period in which rule notifications cease. Alerts change from active to maintenance status.',
+      'Schedule a single or recurring period in which rule notifications cease and alerts are in maintenance mode.',
   }
 );
 
@@ -112,13 +112,6 @@ export const CREATE_FORM_SCHEDULE_DESCRIPTION = i18n.translate(
   }
 );
 
-export const CREATE_FORM_DATE_AND_TIME = i18n.translate(
-  'xpack.alerting.maintenanceWindows.createForm.dateAndTime',
-  {
-    defaultMessage: 'Date and time',
-  }
-);
-
 export const CREATE_FORM_DATE_AND_TIME_REQUIRED = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.dateAndTimeFieldRequiredError',
   {
@@ -157,7 +150,7 @@ export const CREATE_FORM_RECURRING = i18n.translate(
 export const CREATE_FORM_REPEAT = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.repeatLabel',
   {
-    defaultMessage: 'Repeat:',
+    defaultMessage: 'Repeat',
   }
 );
 
@@ -236,7 +229,7 @@ export const CREATE_FORM_FREQUENCY_CUSTOM = i18n.translate(
 export const CREATE_FORM_ENDS = i18n.translate(
   'xpack.alerting.maintenanceWindows.createForm.endsLabel',
   {
-    defaultMessage: 'Ends:',
+    defaultMessage: 'End',
   }
 );
 

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
@@ -59,7 +59,7 @@ export const CREATE_MAINTENANCE_WINDOW_DESCRIPTION = i18n.translate(
   'xpack.alerting.maintenanceWindows.create.description',
   {
     defaultMessage:
-      'Schedule a single or recurring period in which rule notifications cease and alerts temporarily have a maintenance status.',
+      'Schedule a single or recurring period in which rule notifications cease. Alerts change from active to maintenance status.',
   }
 );
 


### PR DESCRIPTION
## Summary

This PR drafts a quick and dirty mock-up of a "Create maintenance window" page that has less space taken up by labels and descriptions (i.e. more like the Index Lifecycle Policy layout):

![image](https://user-images.githubusercontent.com/26471269/229174365-c45a66d6-a0d6-444a-9a13-102d9abf96cb.png)


It also contains some additional edits to the text strings.