### PR TITLE
[ResponseOps][Window Maintenance] Add tooltip for alerts column

### DIFF
--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/maintenance_windows_list.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/maintenance_windows_list.tsx
@@ -11,6 +11,8 @@ import {
   EuiInMemoryTable,
   EuiBasicTableColumn,
   EuiButton,
+  EuiIcon,
+  EuiToolTip,
   formatNumber,
   useEuiBackgroundColor,
 } from '@elastic/eui';
@@ -56,7 +58,14 @@ export const MaintenanceWindowsList = React.memo<MaintenanceWindowsListProps>(
       },
       {
         field: 'total',
-        name: 'Alerts',
+        name: (
+          <EuiToolTip content={i18n.TABLE_ALERTS_TIP}>
+            <span>
+              Alerts{' '}
+              <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+            </span>
+          </EuiToolTip>
+        ),
         render: (alerts: number) => formatNumber(alerts, 'integer'),
       },
       {

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/maintenance_windows_list.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/maintenance_windows_list.tsx
@@ -61,7 +61,7 @@ export const MaintenanceWindowsList = React.memo<MaintenanceWindowsListProps>(
         name: (
           <EuiToolTip content={i18n.TABLE_ALERTS_TIP}>
             <span>
-              Alerts{' '}
+              {i18n.TABLE_ALERTS}{' '}
               <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
             </span>
           </EuiToolTip>

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
@@ -416,3 +416,10 @@ export const TABLE_START_TIME = i18n.translate(
 export const TABLE_END_TIME = i18n.translate('xpack.alerting.maintenanceWindows.table.endTime', {
   defaultMessage: 'End time',
 });
+
+export const TABLE_ALERTS_TIP = i18n.translate(
+  'xpack.alerting.maintenanceWindows.table.alerts.tip',
+  {
+    defaultMessage: 'The total number of alerts created in the maintenance window.',
+  }
+);

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/translations.ts
@@ -417,6 +417,10 @@ export const TABLE_END_TIME = i18n.translate('xpack.alerting.maintenanceWindows.
   defaultMessage: 'End time',
 });
 
+export const TABLE_ALERTS = i18n.translate('xpack.alerting.maintenanceWindows.table.alerts', {
+  defaultMessage: 'Alerts',
+});
+
 export const TABLE_ALERTS_TIP = i18n.translate(
   'xpack.alerting.maintenanceWindows.table.alerts.tip',
   {


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/pull/154491
This PR adds a tooltip to the "Alerts" column in the maintenance window table.

It is based on the way we added tooltips in https://github.com/elastic/kibana/blob/main/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx

### Screenshots

![image](https://user-images.githubusercontent.com/26471269/231240707-2ba5fa90-9afa-4cd7-af4b-4775a1e62bec.png)
